### PR TITLE
Add margin round TV channel icons on home screen now and next

### DIFF
--- a/1080i/Includes_Home.xml
+++ b/1080i/Includes_Home.xml
@@ -425,17 +425,17 @@
                                     <colordiffuse>22FFFFFF</colordiffuse>
                                 </control>
                                 <control type="image">
-                                    <posx>0</posx>
-                                    <posy>0</posy>
-                                    <width>112</width>
-                                    <height>112</height>
-                                    <aspectratio align="right">keep</aspectratio>
+                                    <posx>15</posx>
+                                    <posy>10</posy>
+                                    <width>92</width>
+                                    <height>92</height>
+                                    <aspectratio align="center">keep</aspectratio>
                                     <texture>$INFO[ListItem.Icon]</texture>
                                 </control>
                                 <control type="label">
-                                    <posx>135</posx>
+                                    <posx>130</posx>
                                     <posy>2</posy>
-                                    <width>410</width>
+                                    <width>415</width>
                                     <height>40</height>
                                     <info>ListItem.Label</info>
                                     <font>Font-Condensed-S30</font>
@@ -443,9 +443,9 @@
                                     <align></align>
                                 </control>
                                 <control type="label">
-                                    <posx>135</posx>
+                                    <posx>130</posx>
                                     <posy>26</posy>
-                                    <width>410</width>
+                                    <width>415</width>
                                     <height>60</height>
                                     <label>$LOCALIZE[19030]: $INFO[ListItem.Title]</label>
                                     <font>Font-Condensed-S29</font>
@@ -455,9 +455,9 @@
                                     <align></align>
                                 </control>
                                 <control type="label">
-                                    <posx>135</posx>
+                                    <posx>130</posx>
                                     <posy>59</posy>
-                                    <width>410</width>
+                                    <width>415</width>
                                     <height>60</height>
                                     <label>$INFO[ListItem.StartTime]: $INFO[ListItem.NextTitle]</label>
                                     <font>Font-Condensed-S29</font>
@@ -478,17 +478,17 @@
                                     <colordiffuse>55000000</colordiffuse>
                                 </control>
                                 <control type="image">
-                                    <posx>0</posx>
-                                    <posy>0</posy>
-                                    <width>112</width>
-                                    <height>112</height>
-                                    <aspectratio align="right">keep</aspectratio>
+                                    <posx>15</posx>
+                                    <posy>10</posy>
+                                    <width>92</width>
+                                    <height>92</height>
+                                    <aspectratio align="center">keep</aspectratio>
                                     <texture>$INFO[ListItem.Icon]</texture>
                                 </control>
                                 <control type="label">
-                                    <posx>135</posx>
+                                    <posx>130</posx>
                                     <posy>2</posy>
-                                    <width>410</width>
+                                    <width>415</width>
                                     <height>40</height>
                                     <info>ListItem.Label</info>
                                     <font>Font-Condensed-S30-B</font>
@@ -496,9 +496,9 @@
                                     <align></align>
                                 </control>
                                 <control type="label">
-                                    <posx>135</posx>
+                                    <posx>130</posx>
                                     <posy>26</posy>
-                                    <width>410</width>
+                                    <width>415</width>
                                     <height>60</height>
                                     <label>$LOCALIZE[19030]: $INFO[ListItem.Title]</label>
                                     <font>Font-Condensed-S29</font>
@@ -507,9 +507,9 @@
                                     <align></align>
                                 </control>
                                 <control type="label">
-                                    <posx>135</posx>
+                                    <posx>130</posx>
                                     <posy>59</posy>
-                                    <width>410</width>
+                                    <width>415</width>
                                     <height>60</height>
                                     <label>$INFO[ListItem.StartTime]: $INFO[ListItem.NextTitle]</label>
                                     <font>Font-Condensed-S29</font>


### PR DESCRIPTION
![screenshot000](https://cloud.githubusercontent.com/assets/10114731/9699241/ae28d4b4-541e-11e5-8ba7-fca41b805c74.png)
Channel icons on the Live TV page of the home screen seem cramped, so
add a small margin round them to better match the styling of the TV:
Channels list. Tested on v4.1.0 with Kodi 15.1.
