### PR TITLE
fix some missing labels

### DIFF
--- a/1080i/VideoFullScreen.xml
+++ b/1080i/VideoFullScreen.xml
@@ -2,5 +2,17 @@
 <window>
     <defaultcontrol>-</defaultcontrol>
     <controls>
+        <control type="group" id="0">
+            <control type="label" id="10">
+                <description>row 1 label</description>
+                <posx>130</posx>
+                <posy>20</posy>
+                <width>auto</width>
+                <height>90</height>
+                <textcolor>bbwhite</textcolor>
+                <font>Font-Condensed-S29-B</font>
+                <label>-</label>
+            </control>
+        </control>
     </controls>
 </window>

--- a/1080i/ViewtypesVideos.xml
+++ b/1080i/ViewtypesVideos.xml
@@ -425,7 +425,7 @@
                         <height>98</height>
                         <font>Font-Condensed-S36</font>
                         <align>left</align>
-                        <label>$VAR[ListItem.Season]$VAR[ListItem.Episode]</label>
+                        <label>$INFO[ListItem.Season]$VAR[ListItem.Episode]</label>
                         <selectedcolor>SelectedColor</selectedcolor>
                         <textcolor>aawhite</textcolor>
                         <scroll>false</scroll>
@@ -921,7 +921,7 @@
                             <height>98</height>
                             <font>Font-Condensed-S36</font>
                             <align>left</align>
-                            <label>$VAR[ListItem.Season]$VAR[ListItem.Episode]</label>
+                            <label>$INFO[ListItem.Season]$VAR[ListItem.Episode]</label>
                             <selectedcolor>SelectedColor</selectedcolor>
                             <textcolor>eewhite</textcolor>
                             <scroll>false</scroll>
@@ -1572,7 +1572,7 @@
                             <height>58</height>
                             <width>70</width>
                             <font>Font-Condensed-S31</font>
-                            <label>$VAR[ListItem.Season]$VAR[ListItem.Episode]</label>
+                            <label>$INFO[ListItem.Season]$VAR[ListItem.Episode]</label>
                             <selectedcolor>SelectedColor</selectedcolor>
                             <textcolor>77white</textcolor>
                             <shadowcolor>22000000</shadowcolor>
@@ -1950,7 +1950,7 @@
                                 <height>58</height>
                                 <width>70</width>
                                 <font>Font-Condensed-S31</font>
-                                <label>$VAR[ListItem.Season]$VAR[ListItem.Episode]</label>
+                                <label>$INFO[ListItem.Season]$VAR[ListItem.Episode]</label>
                                 <selectedcolor>SelectedColor</selectedcolor>
                                 <textcolor>eewhite</textcolor>
                                 <shadowcolor>22000000</shadowcolor>
@@ -5224,7 +5224,7 @@
                             <posy>0</posy>
                             <width>100</width>
                             <height>62</height>
-                            <label>$VAR[ListItem.Season]$VAR[ListItem.Episode]</label>
+                            <label>$INFO[ListItem.Season]$VAR[ListItem.Episode]</label>
                             <font>Font-Condensed-S36</font>
                             <selectedcolor>SelectedColor</selectedcolor>
                             <textcolor>77white</textcolor>
@@ -5609,7 +5609,7 @@
                                 <posx>0</posx>
                                 <posy>4</posy>
                                 <width>100</width>
-                                <label>$VAR[ListItem.Season]$VAR[ListItem.Episode]</label>
+                                <label>$INFO[ListItem.Season]$VAR[ListItem.Episode]</label>
                                 <font>Font-Condensed-S36</font>
                                 <textcolor>FF484848</textcolor>
                                 <scroll>false</scroll>


### PR DESCRIPTION
I found two labels that currently are not shown
- the label when you jump to a specific time enternig the numbers

<img src='https://s15.postimg.org/f9jtotqcr/jumptotime.png' border='0' alt='jumptotime'/><br />
- the season number in some viewtypes

before
<img src='https://s12.postimg.org/ylsht4qsd/before.png' border='0' alt="before"/><br/>

after
<img src='https://s12.postimg.org/t93nf02vx/after.png' border='0' alt="after"/><br/>

I know nothing about the skins so feel free to close this PR and do it properly in any other way
